### PR TITLE
Explicitly mark FlutterNetworkCapability public

### DIFF
--- a/android/src/main/kotlin/com/nu/flutter_network_capabilities/FlutterNetworkCapabilitiesPlugin.kt
+++ b/android/src/main/kotlin/com/nu/flutter_network_capabilities/FlutterNetworkCapabilitiesPlugin.kt
@@ -11,7 +11,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 
 /** FlutterNetworkCapabilitiesPlugin */
-class FlutterNetworkCapabilitiesPlugin : FlutterPlugin, MethodCallHandler {
+public class FlutterNetworkCapabilitiesPlugin : FlutterPlugin, MethodCallHandler {
     private lateinit var channel: MethodChannel
     private lateinit var connectivityManager: ConnectivityManager
 


### PR DESCRIPTION
When building the app for the first time using the plugin, the Java compilation cache is empty.

As of right now, this error comes up as the compiler can't find the compiled Kotlin class in the classpath:

```
android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java:144:error:cannot find symbol flutterEngine.getPlugins().add(newcom.nu.flutter_network_capabilities.FlutterNetworkCapabilitiesPluginO);

symbol:
class FlutterNetworkCapabilitiesPlugin

location: package com.nu.flutter_network_capabilities
```

This is caused by the lack of explicit `public` marker on the class. Without it, the Kotlin compiler does not produce a `.class` output for the class, as it cannot detect it's usage.

Adding a `public` solves the issue, even tho Android Studio considers it superfluous